### PR TITLE
Update get-started.md

### DIFF
--- a/guide/get-started.md
+++ b/guide/get-started.md
@@ -18,7 +18,7 @@ We need to override cypress agents configuration to start using the local `direc
 
 ```bash
 # Let's find cypress runner location
-# Create script in the package.json of your project: 
+# Create a script in the package.json of your project: 
 # { "debug": "DEBUG=cypress:* cypress version" }
 
 # execute the script using npm or yarn

--- a/guide/get-started.md
+++ b/guide/get-started.md
@@ -29,7 +29,7 @@ npm run debug
 "cypress:cli Reading binary package.json from: /Users/agoldis/Library/Caches/Cypress/7.0.1/Cypress.app/Contents/Resources/app/package.json +0ms"
 
 # Now let's override cypress agent configuration
-vim /Users/agoldis/Library/Caches/Cypress/6.2.1/Cypress.app/Contents/Resources/app/packages/server/config/app.yml
+vim /Users/agoldis/Library/Caches/Cypress/7.0.1/Cypress.app/Contents/Resources/app/packages/server/config/app.yml
 production:
   # api_url: "https://api.cypress.io/"
   api_url: "http://localhost:1234/"

--- a/guide/get-started.md
+++ b/guide/get-started.md
@@ -18,10 +18,15 @@ We need to override cypress agents configuration to start using the local `direc
 
 ```bash
 # Let's find cypress runner location
-DEBUG=cypress:* cypress version
+# Create script in the package.json of your project: 
+# { "debug": "DEBUG=cypress:* cypress version" }
+
+# execute the script using npm or yarn
+npm run debug
+
 
 # Examine the output, note the path
-"cypress:cli Reading binary package.json from: /Users/agoldis/Library/Caches/Cypress/6.2.1/Cypress.app/Contents/Resources/app/package.json +0ms"
+"cypress:cli Reading binary package.json from: /Users/agoldis/Library/Caches/Cypress/7.0.1/Cypress.app/Contents/Resources/app/package.json +0ms"
 
 # Now let's override cypress agent configuration
 vim /Users/agoldis/Library/Caches/Cypress/6.2.1/Cypress.app/Contents/Resources/app/packages/server/config/app.yml


### PR DESCRIPTION
`$ DEBUG=cypress:* cypress version` 
gives the output  `command not found: cypress`

Hence updated the doc to use the above in an npm script rather than using as a CLI command